### PR TITLE
Fix APPUiO Cloud queries to gracefully handle control-api timeseries …

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -845,7 +845,11 @@ parameters:
                   on(organization)
                   group_left(sales_order)
                   (
-                    appuio_control_organization_info{namespace="appuio-control-api-production"}
+                    # Drop pod and instance labels so we gracefully handle
+                    # short time periods (e.g. during maintenance) where it's
+                    # possible that metrics are scraped from two control-api
+                    # pods.
+                    max without (pod,instance) (appuio_control_organization_info{namespace="appuio-control-api-production"})
                   ),
                   # At least return 128MiB
                   128 * 1024 * 1024
@@ -949,7 +953,11 @@ parameters:
                     on(organization)
                     group_left(sales_order)
                     (
-                      appuio_control_organization_info{namespace="appuio-control-api-production"}
+                      # Drop pod and instance labels so we gracefully handle
+                      # short time periods (e.g. during maintenance) where it's
+                      # possible that metrics are scraped from two control-api
+                      # pods.
+                      max without (pod,instance) (appuio_control_organization_info{namespace="appuio-control-api-production"})
                     )
                   ),
                   1024 * 1024 * 1024
@@ -998,7 +1006,11 @@ parameters:
                 on(organization)
                 group_left(sales_order)
                 (
-                  appuio_control_organization_info{namespace="appuio-control-api-production"}
+                  # Drop pod and instance labels so we gracefully handle
+                  # short time periods (e.g. during maintenance) where it's
+                  # possible that metrics are scraped from two control-api
+                  # pods.
+                  max without (pod,instance) (appuio_control_organization_info{namespace="appuio-control-api-production"})
                 )
               )[59m:1m]
             )

--- a/tests/golden/defaults/appuio-reporting-aldebaran/appuio-reporting-aldebaran/11_backfill.yaml
+++ b/tests/golden/defaults/appuio-reporting-aldebaran/appuio-reporting-aldebaran/11_backfill.yaml
@@ -132,7 +132,11 @@ spec:
                             on(organization)
                             group_left(sales_order)
                             (
-                              appuio_control_organization_info{namespace="appuio-control-api-production"}
+                              # Drop pod and instance labels so we gracefully handle
+                              # short time periods (e.g. during maintenance) where it's
+                              # possible that metrics are scraped from two control-api
+                              # pods.
+                              max without (pod,instance) (appuio_control_organization_info{namespace="appuio-control-api-production"})
                             ),
                             # At least return 128MiB
                             128 * 1024 * 1024
@@ -296,7 +300,11 @@ spec:
                             on(organization)
                             group_left(sales_order)
                             (
-                              appuio_control_organization_info{namespace="appuio-control-api-production"}
+                              # Drop pod and instance labels so we gracefully handle
+                              # short time periods (e.g. during maintenance) where it's
+                              # possible that metrics are scraped from two control-api
+                              # pods.
+                              max without (pod,instance) (appuio_control_organization_info{namespace="appuio-control-api-production"})
                             ),
                             # At least return 128MiB
                             128 * 1024 * 1024
@@ -460,7 +468,11 @@ spec:
                             on(organization)
                             group_left(sales_order)
                             (
-                              appuio_control_organization_info{namespace="appuio-control-api-production"}
+                              # Drop pod and instance labels so we gracefully handle
+                              # short time periods (e.g. during maintenance) where it's
+                              # possible that metrics are scraped from two control-api
+                              # pods.
+                              max without (pod,instance) (appuio_control_organization_info{namespace="appuio-control-api-production"})
                             ),
                             # At least return 128MiB
                             128 * 1024 * 1024
@@ -580,7 +592,11 @@ spec:
                           on(organization)
                           group_left(sales_order)
                           (
-                            appuio_control_organization_info{namespace="appuio-control-api-production"}
+                            # Drop pod and instance labels so we gracefully handle
+                            # short time periods (e.g. during maintenance) where it's
+                            # possible that metrics are scraped from two control-api
+                            # pods.
+                            max without (pod,instance) (appuio_control_organization_info{namespace="appuio-control-api-production"})
                           )
                         )[59m:1m]
                       )
@@ -724,7 +740,11 @@ spec:
                               on(organization)
                               group_left(sales_order)
                               (
-                                appuio_control_organization_info{namespace="appuio-control-api-production"}
+                                # Drop pod and instance labels so we gracefully handle
+                                # short time periods (e.g. during maintenance) where it's
+                                # possible that metrics are scraped from two control-api
+                                # pods.
+                                max without (pod,instance) (appuio_control_organization_info{namespace="appuio-control-api-production"})
                               )
                             ),
                             1024 * 1024 * 1024
@@ -873,7 +893,11 @@ spec:
                               on(organization)
                               group_left(sales_order)
                               (
-                                appuio_control_organization_info{namespace="appuio-control-api-production"}
+                                # Drop pod and instance labels so we gracefully handle
+                                # short time periods (e.g. during maintenance) where it's
+                                # possible that metrics are scraped from two control-api
+                                # pods.
+                                max without (pod,instance) (appuio_control_organization_info{namespace="appuio-control-api-production"})
                               )
                             ),
                             1024 * 1024 * 1024
@@ -1022,7 +1046,11 @@ spec:
                               on(organization)
                               group_left(sales_order)
                               (
-                                appuio_control_organization_info{namespace="appuio-control-api-production"}
+                                # Drop pod and instance labels so we gracefully handle
+                                # short time periods (e.g. during maintenance) where it's
+                                # possible that metrics are scraped from two control-api
+                                # pods.
+                                max without (pod,instance) (appuio_control_organization_info{namespace="appuio-control-api-production"})
                               )
                             ),
                             1024 * 1024 * 1024
@@ -1171,7 +1199,11 @@ spec:
                               on(organization)
                               group_left(sales_order)
                               (
-                                appuio_control_organization_info{namespace="appuio-control-api-production"}
+                                # Drop pod and instance labels so we gracefully handle
+                                # short time periods (e.g. during maintenance) where it's
+                                # possible that metrics are scraped from two control-api
+                                # pods.
+                                max without (pod,instance) (appuio_control_organization_info{namespace="appuio-control-api-production"})
                               )
                             ),
                             1024 * 1024 * 1024
@@ -1320,7 +1352,11 @@ spec:
                               on(organization)
                               group_left(sales_order)
                               (
-                                appuio_control_organization_info{namespace="appuio-control-api-production"}
+                                # Drop pod and instance labels so we gracefully handle
+                                # short time periods (e.g. during maintenance) where it's
+                                # possible that metrics are scraped from two control-api
+                                # pods.
+                                max without (pod,instance) (appuio_control_organization_info{namespace="appuio-control-api-production"})
                               )
                             ),
                             1024 * 1024 * 1024


### PR DESCRIPTION
…overlap

We've observed that there's a chance that we have timeseries from two different control-api pods for a short period of time during the maintenance.

This commit adjust the APPUiO Cloud queries to drop the pod and instance labels on the `appuio_control_organization_info` timeseries to ensure that we don't have duplicate timeseries which break the query.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
