### PR TITLE
Extend the VSHN Managed OpenShift queries to tolerate changes to unused labels

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -507,21 +507,26 @@ parameters:
           max_over_time(
             # Sum the vCPUs by cluster
             sum by(cluster_id, role) (
-                # Get the node vCPUs
-                node_cpu_info
+                # Get the node vCPUs (do not remove `cpu and `core` from the
+                # `by` clause, otherwise the vCPU amount is incorrect)
+                max by (cluster_id, instance, cpu, core) (node_cpu_info)
                 # Limit to worker nodes only
                 * on (cluster_id, instance) group_left(role) (
                     # node_cpu_info and kube_node_role use different labels to identify the node.
-                    label_join(kube_node_role{role="%(role)s"}, "instance", "", "node")
+                    max by (role, instance, cluster_id) (
+                        label_join(kube_node_role{role="%(role)s"}, "instance", "", "node")
+                    )
                 )
             )[59m:1m]
           )
           # Pull in the APPUiO managed info labels
-          * on(cluster_id) group_left(sales_order) appuio_managed_info{
+          * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+            appuio_managed_info{
               cloud_provider=~"%(cloud_provider)s",
               distribution=~"%(distribution)s",
               vshn_service_level="%(vshn_service_level)s",
-          }
+            }
+          )
           , "flavor_display", "%(flavor_display)s", "", "")
 
       appuio_managed_core:
@@ -547,21 +552,26 @@ parameters:
           max_over_time(
             # Sum the vCPUs by cluster
             sum by(cluster_id, role) (
-                # Get the node cores (without hyperthreads)
-                max without (cpu) (node_cpu_info)
+                # Get the node cores (without hyperthreads, otherwise we'd
+                # include `cpu` in the `by`)
+                max by (cluster_id, instance, core) (node_cpu_info)
                 # Limit to worker nodes only
                 * on (cluster_id, instance) group_left(role) (
                     # node_cpu_info and kube_node_role use different labels to identify the node.
-                    label_join(kube_node_role{role="worker"}, "instance", "", "node")
+                    max by (cluster_id, instance, role) (
+                        label_join(kube_node_role{role="worker"}, "instance", "", "node")
+                    )
                 )
             )[59m:1m]
           )
           # Pull in the APPUiO managed info labels
-          * on(cluster_id) group_left(sales_order) appuio_managed_info{
+          * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+            appuio_managed_info{
               cloud_provider=~"%(cloud_provider)s",
               distribution=~"%(distribution)s",
               vshn_service_level="%(vshn_service_level)s",
-          }
+            }
+          )
 
       legacy_appuio_rke_cluster:
         enabled: true
@@ -1052,18 +1062,22 @@ parameters:
             # Sum the vCPUs by cluster
             sum by(cluster_id) (
                 # Get the node vCPUs
-                node_cpu_info
+                max by (cluster_id, instance, core, cpu) (node_cpu_info)
                 # Limit to worker nodes only
                 * on (cluster_id, instance) group_left(role) (
                     # node_cpu_info and kube_node_role use different labels to identify the node.
-                    label_join(kube_node_role{role=~"app|storage"}, "instance", "", "node")
+                    max by (cluster_id, instance, role) (
+                        label_join(kube_node_role{role=~"app|storage"}, "instance", "", "node")
+                    )
                 )
             )[59m:1m]
           )
           # Pull in the APPUiO managed info labels
-          * on(cluster_id) group_left(sales_order) appuio_managed_info{
+          * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+            appuio_managed_info{
               vshn_service_level=~"%(vshn_service_level)s",
               cilium_addons=~".*%(cilium_addon)s.*"
-          }
+            }
+          )
           , "cilium_addon", "%(cilium_addon)s", "", "")
           , "addon_display", "%(addon_display)s", "", "")

--- a/querytests/appuio_managed_core.jsonnet
+++ b/querytests/appuio_managed_core.jsonnet
@@ -1,12 +1,12 @@
-local c = import 'promtest.libsonnet'; // provided by promtest-jsonnet
+local c = import 'promtest.libsonnet';  // provided by promtest-jsonnet
 
-local config = std.extVar("main.yml");
-local queryPattern = config.parameters.appuio_reporting_aldebaran.rules.appuio_managed_core.query_pattern ;
+local config = std.extVar('main.yml');
+local queryPattern = config.parameters.appuio_reporting_aldebaran.rules.appuio_managed_core.query_pattern;
 
 local appParams = {
-  cloud_provider: "baremetal",
-  distribution: "oke",
-  vshn_service_level: "best_effort",
+  cloud_provider: 'baremetal',
+  distribution: 'oke',
+  vshn_service_level: 'best_effort',
 };
 
 local commonLabels = {
@@ -56,9 +56,59 @@ local baseSeries = {
   appuioInfoLabel: c.series('appuio_managed_info', infoLabels, '1x120'),
 };
 
+local displayNameChange = {
+  appNodeRoleLabel: c.series('kube_node_role', commonLabels {
+    node: 'app-test',
+    role: 'worker',
+    cluster_name: 'foo',
+  }, '1x60 _x60') + c.series('kube_node_role', commonLabels {
+    node: 'app-test',
+    role: 'worker',
+    cluster_name: 'Foo',
+  }, '_x60 1x60'),
+
+  appNodeCPUInfoLabel0: c.series('node_cpu_info', commonLabels {
+    instance: 'app-test',
+    cpu: '1',
+    core: '0',
+    cluster_name: 'foo',
+  }, '1x60 _x60') + c.series('node_cpu_info', commonLabels {
+    instance: 'app-test',
+    cpu: '1',
+    core: '0',
+    cluster_name: 'Foo',
+  }, '_x60 1x60'),
+  appNodeCPUInfoLabel2: c.series('node_cpu_info', commonLabels {
+    instance: 'app-test',
+    cpu: '2',
+    core: '0',
+    cluster_name: 'foo',
+  }, '1x60 _x60') + c.series('node_cpu_info', commonLabels {
+    instance: 'app-test',
+    cpu: '2',
+    core: '0',
+    cluster_name: 'Foo',
+  }, '_x60 1x60'),
+  appNodeCPUInfoLabel1: c.series('node_cpu_info', commonLabels {
+    instance: 'app-test',
+    cpu: '1',
+    core: '1',
+    cluster_name: 'foo',
+  }, '1x60 _x60') + c.series('node_cpu_info', commonLabels {
+    instance: 'app-test',
+    cpu: '1',
+    core: '1',
+    cluster_name: 'Foo',
+  }, '_x60 1x60'),
+
+  appuioInfoLabel:
+    c.series('appuio_managed_info', infoLabels { cluster_name: 'foo' }, '1x60 _x60') +
+    c.series('appuio_managed_info', infoLabels { cluster_name: 'Foo' }, '_x60 1x60'),
+};
+
 local baseCalculatedLabels = {
-  cluster_id: "c-managed-openshift",
-  sales_order: "SO123123",
+  cluster_id: 'c-managed-openshift',
+  sales_order: 'SO123123',
 };
 
 {
@@ -77,9 +127,22 @@ local baseCalculatedLabels = {
       ]
     ),
     c.test(
+      'two app CPUs with display name change',
+      baseSeries + displayNameChange,
+      queryPattern % appParams,
+      [
+        {
+          labels: c.formatLabels(baseCalculatedLabels {
+            role: 'worker',
+          }),
+          value: 2,
+        },
+      ]
+    ),
+    c.test(
       'no openshift',
       baseSeries {
-        appuioInfoLabel: c.series('appuio_managed_info', infoLabels {distribution: 'openshift4'}, '1x120')
+        appuioInfoLabel: c.series('appuio_managed_info', infoLabels { distribution: 'openshift4' }, '1x120'),
       },
       queryPattern % appParams,
       [

--- a/querytests/appuio_managed_vcpu.jsonnet
+++ b/querytests/appuio_managed_vcpu.jsonnet
@@ -1,21 +1,21 @@
-local c = import 'promtest.libsonnet'; // provided by promtest-jsonnet
+local c = import 'promtest.libsonnet';  // provided by promtest-jsonnet
 
-local config = std.extVar("main.yml");
-local queryPattern = config.parameters.appuio_reporting_aldebaran.rules.appuio_managed_vcpu.query_pattern ;
+local config = std.extVar('main.yml');
+local queryPattern = config.parameters.appuio_reporting_aldebaran.rules.appuio_managed_vcpu.query_pattern;
 
 local appParams = {
-  cloud_provider: "cloudscale",
-  vshn_service_level: "best_effort",
-  distribution: "openshift4",
-  role: "app",
-  flavor_display: "OpenShift Container Platform"
+  cloud_provider: 'cloudscale',
+  vshn_service_level: 'best_effort',
+  distribution: 'openshift4',
+  role: 'app',
+  flavor_display: 'OpenShift Container Platform',
 };
 local storageParams = {
-  cloud_provider: "cloudscale",
-  vshn_service_level: "best_effort",
-  distribution: "openshift4",
-  role: "storage",
-  flavor_display: "OpenShift Container Platform"
+  cloud_provider: 'cloudscale',
+  vshn_service_level: 'best_effort',
+  distribution: 'openshift4',
+  role: 'storage',
+  flavor_display: 'OpenShift Container Platform',
 };
 
 local commonLabels = {
@@ -58,10 +58,44 @@ local baseSeries = {
   appuioInfoLabel: c.series('appuio_managed_info', infoLabels, '1x120'),
 };
 
+local displayNameChange = {
+  appNodeRoleLabel: c.series('kube_node_role', commonLabels {
+    node: 'app-test',
+    role: 'app',
+    cluster_name: 'foo',
+  }, '1x60 _x60') + c.series('kube_node_role', commonLabels {
+    node: 'app-test',
+    role: 'app',
+    cluster_name: 'Foo',
+  }, '_x60 1x60'),
+  appNodeCPUInfoLabel0: c.series('node_cpu_info', commonLabels {
+    instance: 'app-test',
+    core: '0',
+    cluster_name: 'foo',
+  }, '1x60 _x60') + c.series('node_cpu_info', commonLabels {
+    instance: 'app-test',
+    core: '0',
+    cluster_name: 'Foo',
+  }, '_x60 1x60'),
+  appNodeCPUInfoLabel1: c.series('node_cpu_info', commonLabels {
+    instance: 'app-test',
+    core: '1',
+    cluster_name: 'foo',
+  }, '1x60 _x60') + c.series('node_cpu_info', commonLabels {
+    instance: 'app-test',
+    core: '1',
+    cluster_name: 'Foo',
+  }, '_x60 1x60'),
+
+  appuioInfoLabel:
+    c.series('appuio_managed_info', infoLabels { cluster_name: 'foo' }, '1x60 _x60') +
+    c.series('appuio_managed_info', infoLabels { cluster_name: 'Foo' }, '_x60 1x60'),
+};
+
 local baseCalculatedLabels = {
-  cluster_id: "c-managed-openshift",
-  sales_order: "SO123123",
-  flavor_display: "OpenShift Container Platform",
+  cluster_id: 'c-managed-openshift',
+  sales_order: 'SO123123',
+  flavor_display: 'OpenShift Container Platform',
 };
 
 {
@@ -89,6 +123,19 @@ local baseCalculatedLabels = {
             role: 'storage',
           }),
           value: 1,
+        },
+      ]
+    ),
+    c.test(
+      'and two app CPUs with a display name change',
+      baseSeries + displayNameChange,
+      queryPattern % appParams,
+      [
+        {
+          labels: c.formatLabels(baseCalculatedLabels {
+            role: 'app',
+          }),
+          value: 2,
         },
       ]
     ),

--- a/querytests/cilium_addons.jsonnet
+++ b/querytests/cilium_addons.jsonnet
@@ -1,17 +1,17 @@
-local c = import 'promtest.libsonnet'; // provided by promtest-jsonnet
+local c = import 'promtest.libsonnet';  // provided by promtest-jsonnet
 
-local config = std.extVar("main.yml");
-local queryPattern = config.parameters.appuio_reporting_aldebaran.rules.cilium_addons.query_pattern ;
+local config = std.extVar('main.yml');
+local queryPattern = config.parameters.appuio_reporting_aldebaran.rules.cilium_addons.query_pattern;
 
 local advancedParams = {
-  vshn_service_level: "best_effort",
+  vshn_service_level: 'best_effort',
   cilium_addon: 'advanced',
-  addon_display: "Advanced Networking",
+  addon_display: 'Advanced Networking',
 };
 local tetragonParams = {
-  vshn_service_level: "best_effort",
+  vshn_service_level: 'best_effort',
   cilium_addon: 'tetragon',
-  addon_display: "Tetragon",
+  addon_display: 'Tetragon',
 };
 
 local commonLabels = {
@@ -53,9 +53,44 @@ local baseSeries = {
   appuioInfoLabel: c.series('appuio_managed_info', infoLabels, '1x120'),
 };
 
+local displayNameChange = {
+  appNodeRoleLabel: c.series('kube_node_role', commonLabels {
+    node: 'app-test',
+    role: 'app',
+    cluster_name: 'foo',
+  }, '1x60 _x60') + c.series('kube_node_role', commonLabels {
+    node: 'app-test',
+    role: 'app',
+    cluster_name: 'Foo',
+  }, '_x60 1x60'),
+
+  appNodeCPUInfoLabel0: c.series('node_cpu_info', commonLabels {
+    instance: 'app-test',
+    core: '0',
+    cluster_name: 'foo',
+  }, '1x60 _x60') + c.series('node_cpu_info', commonLabels {
+    instance: 'app-test',
+    core: '0',
+    cluster_name: 'Foo',
+  }, '_x60 1x60'),
+  appNodeCPUInfoLabel1: c.series('node_cpu_info', commonLabels {
+    instance: 'app-test',
+    core: '1',
+    cluster_name: 'foo',
+  }, '1x60 _x60') + c.series('node_cpu_info', commonLabels {
+    instance: 'app-test',
+    core: '1',
+    cluster_name: 'Foo',
+  }, '_x60 1x60'),
+
+  appuioInfoLabel:
+    c.series('appuio_managed_info', infoLabels { cluster_name: 'foo' }, '1x60 _x60') +
+    c.series('appuio_managed_info', infoLabels { cluster_name: 'Foo' }, '_x60 1x60'),
+};
+
 local baseCalculatedLabels = {
-  cluster_id: "c-managed-openshift",
-  sales_order: "SO123123",
+  cluster_id: 'c-managed-openshift',
+  sales_order: 'SO123123',
 };
 
 {
@@ -67,8 +102,22 @@ local baseCalculatedLabels = {
       [
         {
           labels: c.formatLabels(baseCalculatedLabels {
-            cilium_addon: "advanced",
-            addon_display: "Advanced Networking",
+            cilium_addon: 'advanced',
+            addon_display: 'Advanced Networking',
+          }),
+          value: 3,
+        },
+      ]
+    ),
+    c.test(
+      'total CPUs with name change',
+      baseSeries + displayNameChange,
+      queryPattern % advancedParams,
+      [
+        {
+          labels: c.formatLabels(baseCalculatedLabels {
+            cilium_addon: 'advanced',
+            addon_display: 'Advanced Networking',
           }),
           value: 3,
         },
@@ -81,12 +130,12 @@ local baseCalculatedLabels = {
       [
         {
           labels: c.formatLabels(baseCalculatedLabels {
-            cilium_addon: "tetragon",
-            addon_display: "Tetragon",
+            cilium_addon: 'tetragon',
+            addon_display: 'Tetragon',
           }),
           value: 3,
         },
       ]
-    )
+    ),
   ],
 }

--- a/tests/golden/defaults/appuio-reporting-aldebaran/appuio-reporting-aldebaran/11_backfill.yaml
+++ b/tests/golden/defaults/appuio-reporting-aldebaran/appuio-reporting-aldebaran/11_backfill.yaml
@@ -1455,21 +1455,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node cores (without hyperthreads)
-                          max without (cpu) (node_cpu_info)
+                          # Get the node cores (without hyperthreads, otherwise we'd
+                          # include `cpu` in the `by`)
+                          max by (cluster_id, instance, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="worker"}, "instance", "", "node")
+                              max by (cluster_id, instance, role) (
+                                  label_join(kube_node_role{role="worker"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"baremetal",
                         distribution=~"oke",
                         vshn_service_level="best_effort",
-                    }
+                      }
+                    )
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-cores-%(cluster_id)s-%(role)s"
                     % labels
@@ -1559,21 +1564,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node cores (without hyperthreads)
-                          max without (cpu) (node_cpu_info)
+                          # Get the node cores (without hyperthreads, otherwise we'd
+                          # include `cpu` in the `by`)
+                          max by (cluster_id, instance, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="worker"}, "instance", "", "node")
+                              max by (cluster_id, instance, role) (
+                                  label_join(kube_node_role{role="worker"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"baremetal",
                         distribution=~"oke",
                         vshn_service_level="guaranteed_availability",
-                    }
+                      }
+                    )
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-cores-%(cluster_id)s-%(role)s"
                     % labels
@@ -1664,21 +1674,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"cloudscale",
                         distribution=~"openshift4",
                         vshn_service_level="best_effort",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -1770,21 +1785,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"cloudscale",
                         distribution=~"openshift4",
                         vshn_service_level="guaranteed_availability",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -1876,21 +1896,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"cloudscale",
                         distribution=~"openshift4",
                         vshn_service_level="premium",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -1982,21 +2007,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"cloudscale",
                         distribution=~"openshift4",
                         vshn_service_level="professional",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -2088,21 +2118,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"cloudscale",
                         distribution=~"openshift4",
                         vshn_service_level="standard",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -2194,21 +2229,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"cloudscale",
                         distribution=~"openshift4",
                         vshn_service_level="best_effort",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -2300,21 +2340,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"cloudscale",
                         distribution=~"openshift4",
                         vshn_service_level="guaranteed_availability",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -2406,21 +2451,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"cloudscale",
                         distribution=~"openshift4",
                         vshn_service_level="premium",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -2512,21 +2562,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"cloudscale",
                         distribution=~"openshift4",
                         vshn_service_level="professional",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -2618,21 +2673,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"cloudscale",
                         distribution=~"openshift4",
                         vshn_service_level="standard",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -2724,21 +2784,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"cloudscale",
                         distribution=~"openshift4",
                         vshn_service_level="zero",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -2830,21 +2895,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"cloudscale",
                         distribution=~"oke",
                         vshn_service_level="best_effort",
-                    }
+                      }
+                    )
                     , "flavor_display", "Kubernetes Engine", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -2936,21 +3006,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"cloudscale",
                         distribution=~"oke",
                         vshn_service_level="guaranteed_availability",
-                    }
+                      }
+                    )
                     , "flavor_display", "Kubernetes Engine", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -3042,21 +3117,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"exoscale",
                         distribution=~"openshift4",
                         vshn_service_level="best_effort",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -3148,21 +3228,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"exoscale",
                         distribution=~"openshift4",
                         vshn_service_level="guaranteed_availability",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -3254,21 +3339,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"exoscale",
                         distribution=~"openshift4",
                         vshn_service_level="premium",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -3360,21 +3450,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"exoscale",
                         distribution=~"openshift4",
                         vshn_service_level="professional",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -3466,21 +3561,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"exoscale",
                         distribution=~"openshift4",
                         vshn_service_level="standard",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -3572,21 +3672,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"exoscale",
                         distribution=~"openshift4",
                         vshn_service_level="best_effort",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -3678,21 +3783,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"exoscale",
                         distribution=~"openshift4",
                         vshn_service_level="guaranteed_availability",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -3784,21 +3894,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"exoscale",
                         distribution=~"openshift4",
                         vshn_service_level="premium",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -3890,21 +4005,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"exoscale",
                         distribution=~"openshift4",
                         vshn_service_level="professional",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -3996,21 +4116,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"exoscale",
                         distribution=~"openshift4",
                         vshn_service_level="standard",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -4102,21 +4227,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"exoscale",
                         distribution=~"openshift4",
                         vshn_service_level="zero",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -4208,21 +4338,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"openstackcsp",
                         distribution=~"openshift4",
                         vshn_service_level="best_effort",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -4314,21 +4449,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"openstackcsp",
                         distribution=~"openshift4",
                         vshn_service_level="guaranteed_availability",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -4420,21 +4560,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"openstackcsp",
                         distribution=~"openshift4",
                         vshn_service_level="premium",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -4526,21 +4671,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"openstackcsp",
                         distribution=~"openshift4",
                         vshn_service_level="professional",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -4632,21 +4782,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"openstackcsp",
                         distribution=~"openshift4",
                         vshn_service_level="standard",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -4738,21 +4893,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"openstackcsp",
                         distribution=~"openshift4",
                         vshn_service_level="zero",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -4844,21 +5004,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"openstack|openstackonprem",
                         distribution=~"openshift4",
                         vshn_service_level="best_effort",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -4950,21 +5115,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"openstack|openstackonprem",
                         distribution=~"openshift4",
                         vshn_service_level="guaranteed_availability",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -5056,21 +5226,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"openstack|openstackonprem",
                         distribution=~"openshift4",
                         vshn_service_level="premium",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -5162,21 +5337,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"openstack|openstackonprem",
                         distribution=~"openshift4",
                         vshn_service_level="professional",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -5268,21 +5448,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"openstack|openstackonprem",
                         distribution=~"openshift4",
                         vshn_service_level="standard",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -5374,21 +5559,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"openstack|openstackonprem",
                         distribution=~"openshift4",
                         vshn_service_level="zero",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -5480,21 +5670,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"vspherecsp",
                         distribution=~"openshift4",
                         vshn_service_level="best_effort",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -5586,21 +5781,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"vspherecsp",
                         distribution=~"openshift4",
                         vshn_service_level="guaranteed_availability",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -5692,21 +5892,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"vspherecsp",
                         distribution=~"openshift4",
                         vshn_service_level="premium",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -5798,21 +6003,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"vspherecsp",
                         distribution=~"openshift4",
                         vshn_service_level="professional",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -5904,21 +6114,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"vspherecsp",
                         distribution=~"openshift4",
                         vshn_service_level="standard",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -6010,21 +6225,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"vspherecsp",
                         distribution=~"openshift4",
                         vshn_service_level="zero",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -6116,21 +6336,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"none|vsphere|vsphereonprem",
                         distribution=~"openshift4",
                         vshn_service_level="best_effort",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -6222,21 +6447,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"none|vsphere|vsphereonprem",
                         distribution=~"openshift4",
                         vshn_service_level="guaranteed_availability",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -6328,21 +6558,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"none|vsphere|vsphereonprem",
                         distribution=~"openshift4",
                         vshn_service_level="premium",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -6434,21 +6669,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"none|vsphere|vsphereonprem",
                         distribution=~"openshift4",
                         vshn_service_level="professional",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -6540,21 +6780,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"none|vsphere|vsphereonprem",
                         distribution=~"openshift4",
                         vshn_service_level="standard",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -6646,21 +6891,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"none|vsphere|vsphereonprem",
                         distribution=~"openshift4",
                         vshn_service_level="zero",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -6752,21 +7002,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"xelon",
                         distribution=~"openshift4",
                         vshn_service_level="best_effort",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -6858,21 +7113,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"xelon",
                         distribution=~"openshift4",
                         vshn_service_level="guaranteed_availability",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -6964,21 +7224,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"xelon",
                         distribution=~"openshift4",
                         vshn_service_level="premium",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -7070,21 +7335,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"xelon",
                         distribution=~"openshift4",
                         vshn_service_level="professional",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -7176,21 +7446,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"xelon",
                         distribution=~"openshift4",
                         vshn_service_level="standard",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -7282,21 +7557,26 @@ spec:
                     max_over_time(
                       # Sum the vCPUs by cluster
                       sum by(cluster_id, role) (
-                          # Get the node vCPUs
-                          node_cpu_info
+                          # Get the node vCPUs (do not remove `cpu and `core` from the
+                          # `by` clause, otherwise the vCPU amount is incorrect)
+                          max by (cluster_id, instance, cpu, core) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              max by (role, instance, cluster_id) (
+                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         cloud_provider=~"xelon",
                         distribution=~"openshift4",
                         vshn_service_level="zero",
-                    }
+                      }
+                    )
                     , "flavor_display", "Container Platform", "", "")
                 - name: AR_INSTANCE_JSONNET
                   value: local labels = std.extVar("labels"); "ocp-vcpu-%(cluster_id)s-%(role)s"
@@ -7390,19 +7670,23 @@ spec:
                       # Sum the vCPUs by cluster
                       sum by(cluster_id) (
                           # Get the node vCPUs
-                          node_cpu_info
+                          max by (cluster_id, instance, core, cpu) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role=~"app|storage"}, "instance", "", "node")
+                              max by (cluster_id, instance, role) (
+                                  label_join(kube_node_role{role=~"app|storage"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         vshn_service_level=~"best_effort|zero|standard",
                         cilium_addons=~".*advanced_networking.*"
-                    }
+                      }
+                    )
                     , "cilium_addon", "advanced_networking", "", "")
                     , "addon_display", "Advanced Networking and Observability", "", "")
                 - name: AR_INSTANCE_JSONNET
@@ -7497,19 +7781,23 @@ spec:
                       # Sum the vCPUs by cluster
                       sum by(cluster_id) (
                           # Get the node vCPUs
-                          node_cpu_info
+                          max by (cluster_id, instance, core, cpu) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role=~"app|storage"}, "instance", "", "node")
+                              max by (cluster_id, instance, role) (
+                                  label_join(kube_node_role{role=~"app|storage"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         vshn_service_level=~"guaranteed_availability|professional",
                         cilium_addons=~".*advanced_networking.*"
-                    }
+                      }
+                    )
                     , "cilium_addon", "advanced_networking", "", "")
                     , "addon_display", "Advanced Networking and Observability", "", "")
                 - name: AR_INSTANCE_JSONNET
@@ -7604,19 +7892,23 @@ spec:
                       # Sum the vCPUs by cluster
                       sum by(cluster_id) (
                           # Get the node vCPUs
-                          node_cpu_info
+                          max by (cluster_id, instance, core, cpu) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role=~"app|storage"}, "instance", "", "node")
+                              max by (cluster_id, instance, role) (
+                                  label_join(kube_node_role{role=~"app|storage"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         vshn_service_level=~"best_effort|zero|standard",
                         cilium_addons=~".*tetragon.*"
-                    }
+                      }
+                    )
                     , "cilium_addon", "tetragon", "", "")
                     , "addon_display", "Tetragon", "", "")
                 - name: AR_INSTANCE_JSONNET
@@ -7711,19 +8003,23 @@ spec:
                       # Sum the vCPUs by cluster
                       sum by(cluster_id) (
                           # Get the node vCPUs
-                          node_cpu_info
+                          max by (cluster_id, instance, core, cpu) (node_cpu_info)
                           # Limit to worker nodes only
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
-                              label_join(kube_node_role{role=~"app|storage"}, "instance", "", "node")
+                              max by (cluster_id, instance, role) (
+                                  label_join(kube_node_role{role=~"app|storage"}, "instance", "", "node")
+                              )
                           )
                       )[59m:1m]
                     )
                     # Pull in the APPUiO managed info labels
-                    * on(cluster_id) group_left(sales_order) appuio_managed_info{
+                    * on(cluster_id) group_left(sales_order) max by (cluster_id, sales_order) (
+                      appuio_managed_info{
                         vshn_service_level=~"guaranteed_availability|professional",
                         cilium_addons=~".*tetragon.*"
-                    }
+                      }
+                    )
                     , "cilium_addon", "tetragon", "", "")
                     , "addon_display", "Tetragon", "", "")
                 - name: AR_INSTANCE_JSONNET


### PR DESCRIPTION
We extend the queries with `max by (relevant_label_set)` where necessary to ensure that changes to unused labels (e.g. `cluster_name`) don't break the billing queries.

Note that the list of labels which we keep for `node_cpu_info` must contain `core` and `cpu` for the vCPU-Hour billed clusters. The same list must contain `core` but mustn't contain `cpu` for the Core-Hour billed clusters.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.


<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
