### PR TITLE
Bill custom non-app nodes

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -123,6 +123,7 @@ parameters:
             params:
               cloud_provider: cloudscale
               role: storage
+              not_role: ""
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: best_effort
@@ -130,6 +131,7 @@ parameters:
             params:
               cloud_provider: cloudscale
               role: storage
+              not_role: ""
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: guaranteed_availability
@@ -137,6 +139,7 @@ parameters:
             params:
               cloud_provider: cloudscale
               role: storage
+              not_role: ""
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: premium
@@ -144,6 +147,7 @@ parameters:
             params:
               cloud_provider: cloudscale
               role: storage
+              not_role: ""
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: professional
@@ -151,62 +155,71 @@ parameters:
             params:
               cloud_provider: cloudscale
               role: storage
+              not_role: ""
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: standard
           - product_id: 'openshift-cloudscale-workervcpu-besteffort'
             params:
               cloud_provider: cloudscale
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: best_effort
           - product_id: 'openshift-cloudscale-workervcpu-guaranteed'
             params:
               cloud_provider: cloudscale
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: guaranteed_availability
           - product_id: 'openshift-cloudscale-workervcpu-premium'
             params:
               cloud_provider: cloudscale
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: premium
           - product_id: 'openshift-cloudscale-workervcpu-professional'
             params:
               cloud_provider: cloudscale
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: professional
           - product_id: 'openshift-cloudscale-workervcpu-standard'
             params:
               cloud_provider: cloudscale
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: standard
           - product_id: 'openshift-cloudscale-workervcpu-zero'
             params:
               cloud_provider: cloudscale
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: zero
           - product_id: openshiftoke-cloudscale-workervcpu-besteffort
             params:
               cloud_provider: cloudscale
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: oke
               flavor_display: Kubernetes Engine
               vshn_service_level: best_effort
           - product_id: openshiftoke-cloudscale-workervcpu-guaranteed
             params:
               cloud_provider: cloudscale
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: oke
               flavor_display: Kubernetes Engine
               vshn_service_level: guaranteed_availability
@@ -214,6 +227,7 @@ parameters:
             params:
               cloud_provider: exoscale
               role: storage
+              not_role: ""
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: best_effort
@@ -221,6 +235,7 @@ parameters:
             params:
               cloud_provider: exoscale
               role: storage
+              not_role: ""
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: guaranteed_availability
@@ -228,6 +243,7 @@ parameters:
             params:
               cloud_provider: exoscale
               role: storage
+              not_role: ""
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: premium
@@ -235,6 +251,7 @@ parameters:
             params:
               cloud_provider: exoscale
               role: storage
+              not_role: ""
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: professional
@@ -242,258 +259,295 @@ parameters:
             params:
               cloud_provider: exoscale
               role: storage
+              not_role: ""
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: standard
           - product_id: 'openshift-exoscale-workervcpu-besteffort'
             params:
               cloud_provider: exoscale
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: best_effort
           - product_id: 'openshift-exoscale-workervcpu-guaranteed'
             params:
               cloud_provider: exoscale
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: guaranteed_availability
           - product_id: 'openshift-exoscale-workervcpu-premium'
             params:
               cloud_provider: exoscale
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: premium
           - product_id: 'openshift-exoscale-workervcpu-professional'
             params:
               cloud_provider: exoscale
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: professional
           - product_id: 'openshift-exoscale-workervcpu-standard'
             params:
               cloud_provider: exoscale
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: standard
           - product_id: 'openshift-exoscale-workervcpu-zero'
             params:
               cloud_provider: exoscale
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: zero
           - product_id: 'openshift-openstackcsp-workervcpu-besteffort'
             params:
               cloud_provider: openstackcsp
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: best_effort
           - product_id: 'openshift-openstackcsp-workervcpu-guaranteed'
             params:
               cloud_provider: openstackcsp
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: guaranteed_availability
           - product_id: 'openshift-openstackcsp-workervcpu-premium'
             params:
               cloud_provider: openstackcsp
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: premium
           - product_id: 'openshift-openstackcsp-workervcpu-professional'
             params:
               cloud_provider: openstackcsp
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: professional
           - product_id: 'openshift-openstackcsp-workervcpu-standard'
             params:
               cloud_provider: openstackcsp
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: standard
           - product_id: 'openshift-openstackcsp-workervcpu-zero'
             params:
               cloud_provider: openstackcsp
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: zero
           - product_id: 'openshift-openstackonprem-workervcpu-besteffort'
             params:
               cloud_provider: openstack|openstackonprem
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: best_effort
           - product_id: 'openshift-openstackonprem-workervcpu-guaranteed'
             params:
               cloud_provider: openstack|openstackonprem
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: guaranteed_availability
           - product_id: 'openshift-openstackonprem-workervcpu-premium'
             params:
               cloud_provider: openstack|openstackonprem
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: premium
           - product_id: 'openshift-openstackonprem-workervcpu-professional'
             params:
               cloud_provider: openstack|openstackonprem
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: professional
           - product_id: 'openshift-openstackonprem-workervcpu-standard'
             params:
               cloud_provider: openstack|openstackonprem
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: standard
           - product_id: 'openshift-openstackonprem-workervcpu-zero'
             params:
               cloud_provider: openstack|openstackonprem
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: zero
           - product_id: 'openshift-vspherecsp-workervcpu-besteffort'
             params:
               cloud_provider: vspherecsp
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: best_effort
           - product_id: 'openshift-vspherecsp-workervcpu-guaranteed'
             params:
               cloud_provider: vspherecsp
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: guaranteed_availability
           - product_id: 'openshift-vspherecsp-workervcpu-premium'
             params:
               cloud_provider: vspherecsp
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: premium
           - product_id: 'openshift-vspherecsp-workervcpu-professional'
             params:
               cloud_provider: vspherecsp
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: professional
           - product_id: 'openshift-vspherecsp-workervcpu-standard'
             params:
               cloud_provider: vspherecsp
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: standard
           - product_id: 'openshift-vspherecsp-workervcpu-zero'
             params:
               cloud_provider: vspherecsp
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: zero
           - product_id: 'openshift-vsphereonprem-workervcpu-besteffort'
             params:
               cloud_provider: none|vsphere|vsphereonprem
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: best_effort
           - product_id: 'openshift-vsphereonprem-workervcpu-guaranteed'
             params:
               cloud_provider: none|vsphere|vsphereonprem
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: guaranteed_availability
           - product_id: 'openshift-vsphereonprem-workervcpu-premium'
             params:
               cloud_provider: none|vsphere|vsphereonprem
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: premium
           - product_id: 'openshift-vsphereonprem-workervcpu-professional'
             params:
               cloud_provider: none|vsphere|vsphereonprem
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: professional
           - product_id: 'openshift-vsphereonprem-workervcpu-standard'
             params:
               cloud_provider: none|vsphere|vsphereonprem
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: standard
           - product_id: 'openshift-vsphereonprem-workervcpu-zero'
             params:
               cloud_provider: none|vsphere|vsphereonprem
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: zero
           - product_id: 'openshift-xelon-workervcpu-besteffort'
             params:
               cloud_provider: xelon
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: best_effort
           - product_id: 'openshift-xelon-workervcpu-guaranteed'
             params:
               cloud_provider: xelon
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: guaranteed_availability
           - product_id: 'openshift-xelon-workervcpu-premium'
             params:
               cloud_provider: xelon
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: premium
           - product_id: 'openshift-xelon-workervcpu-professional'
             params:
               cloud_provider: xelon
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: professional
           - product_id: 'openshift-xelon-workervcpu-standard'
             params:
               cloud_provider: xelon
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: standard
           - product_id: 'openshift-xelon-workervcpu-zero'
             params:
               cloud_provider: xelon
-              role: app
+              role: worker
+              not_role: infra|storage
               distribution: openshift4
               flavor_display: Container Platform
               vshn_service_level: zero
@@ -514,7 +568,7 @@ parameters:
                 * on (cluster_id, instance) group_left(role) (
                     # node_cpu_info and kube_node_role use different labels to identify the node.
                     max by (role, instance, cluster_id) (
-                        label_join(kube_node_role{role="%(role)s"}, "instance", "", "node")
+                        label_join(kube_node_role{role="%(role)s",role!~"%(not_role)s"}, "instance", "", "node")
                     )
                 )
             )[59m:1m]

--- a/tests/golden/defaults/appuio-reporting-aldebaran/appuio-reporting-aldebaran/11_backfill.yaml
+++ b/tests/golden/defaults/appuio-reporting-aldebaran/appuio-reporting-aldebaran/11_backfill.yaml
@@ -1849,7 +1849,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="storage",role!~""}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -1960,7 +1960,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="storage",role!~""}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -2071,7 +2071,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="storage",role!~""}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -2182,7 +2182,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="storage",role!~""}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -2293,7 +2293,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="storage",role!~""}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -2404,7 +2404,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -2515,7 +2515,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -2626,7 +2626,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -2737,7 +2737,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -2848,7 +2848,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -2959,7 +2959,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -3070,7 +3070,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -3181,7 +3181,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -3292,7 +3292,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="storage",role!~""}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -3403,7 +3403,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="storage",role!~""}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -3514,7 +3514,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="storage",role!~""}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -3625,7 +3625,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="storage",role!~""}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -3736,7 +3736,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="storage"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="storage",role!~""}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -3847,7 +3847,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -3958,7 +3958,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -4069,7 +4069,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -4180,7 +4180,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -4291,7 +4291,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -4402,7 +4402,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -4513,7 +4513,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -4624,7 +4624,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -4735,7 +4735,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -4846,7 +4846,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -4957,7 +4957,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -5068,7 +5068,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -5179,7 +5179,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -5290,7 +5290,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -5401,7 +5401,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -5512,7 +5512,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -5623,7 +5623,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -5734,7 +5734,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -5845,7 +5845,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -5956,7 +5956,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -6067,7 +6067,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -6178,7 +6178,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -6289,7 +6289,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -6400,7 +6400,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -6511,7 +6511,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -6622,7 +6622,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -6733,7 +6733,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -6844,7 +6844,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -6955,7 +6955,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -7066,7 +7066,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -7177,7 +7177,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -7288,7 +7288,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -7399,7 +7399,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -7510,7 +7510,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -7621,7 +7621,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]
@@ -7732,7 +7732,7 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (role, instance, cluster_id) (
-                                  label_join(kube_node_role{role="app"}, "instance", "", "node")
+                                  label_join(kube_node_role{role="worker",role!~"infra|storage"}, "instance", "", "node")
                               )
                           )
                       )[59m:1m]


### PR DESCRIPTION
With the advent of the autoscaling feature some customers want special node-roles to schedule their workload. The new query should bill all worker nodes that are not storage or infra.

Warning: This query does not work as the `kube_node_role` label is multi-dimensional.




## Checklist

- [ ] PR contains a single logical change (to build a better changelog).
- [ ] Update the documentation.
- [ ] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.
- [ ] Link this PR to related issues or PRs.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
