### PR TITLE
Limit cilium addon query to clusters which have an addon

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -1143,7 +1143,17 @@ parameters:
                 * on (cluster_id, instance) group_left(role) (
                     # node_cpu_info and kube_node_role use different labels to identify the node.
                     max by (cluster_id, instance, role) (
-                        label_join(kube_node_role{role=~"app|storage"}, "instance", "", "node")
+                      label_join(
+                        kube_node_role{role=~"app|storage"}
+                        # Limit to clusters that we need to bill
+                        * on(cluster_id) group_left () max by (cluster_id) (
+                          appuio_managed_info{
+                            vshn_service_level=~"%(vshn_service_level)s",
+                            cilium_addons=~".*%(cilium_addon)s.*"
+                          }
+                        )
+                        , "instance", "", "node"
+                      )
                     )
                 )
             )[59m:1m]

--- a/tests/golden/defaults/appuio-reporting-aldebaran/appuio-reporting-aldebaran/11_backfill.yaml
+++ b/tests/golden/defaults/appuio-reporting-aldebaran/appuio-reporting-aldebaran/11_backfill.yaml
@@ -8707,7 +8707,17 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (cluster_id, instance, role) (
-                                  label_join(kube_node_role{role=~"app|storage"}, "instance", "", "node")
+                                label_join(
+                                  kube_node_role{role=~"app|storage"}
+                                  # Limit to clusters that we need to bill
+                                  * on(cluster_id) group_left () max by (cluster_id) (
+                                    appuio_managed_info{
+                                      vshn_service_level=~"best_effort|zero|standard",
+                                      cilium_addons=~".*advanced_networking.*"
+                                    }
+                                  )
+                                  , "instance", "", "node"
+                                )
                               )
                           )
                       )[59m:1m]
@@ -8818,7 +8828,17 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (cluster_id, instance, role) (
-                                  label_join(kube_node_role{role=~"app|storage"}, "instance", "", "node")
+                                label_join(
+                                  kube_node_role{role=~"app|storage"}
+                                  # Limit to clusters that we need to bill
+                                  * on(cluster_id) group_left () max by (cluster_id) (
+                                    appuio_managed_info{
+                                      vshn_service_level=~"guaranteed_availability|professional",
+                                      cilium_addons=~".*advanced_networking.*"
+                                    }
+                                  )
+                                  , "instance", "", "node"
+                                )
                               )
                           )
                       )[59m:1m]
@@ -8929,7 +8949,17 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (cluster_id, instance, role) (
-                                  label_join(kube_node_role{role=~"app|storage"}, "instance", "", "node")
+                                label_join(
+                                  kube_node_role{role=~"app|storage"}
+                                  # Limit to clusters that we need to bill
+                                  * on(cluster_id) group_left () max by (cluster_id) (
+                                    appuio_managed_info{
+                                      vshn_service_level=~"best_effort|zero|standard",
+                                      cilium_addons=~".*tetragon.*"
+                                    }
+                                  )
+                                  , "instance", "", "node"
+                                )
                               )
                           )
                       )[59m:1m]
@@ -9040,7 +9070,17 @@ spec:
                           * on (cluster_id, instance) group_left(role) (
                               # node_cpu_info and kube_node_role use different labels to identify the node.
                               max by (cluster_id, instance, role) (
-                                  label_join(kube_node_role{role=~"app|storage"}, "instance", "", "node")
+                                label_join(
+                                  kube_node_role{role=~"app|storage"}
+                                  # Limit to clusters that we need to bill
+                                  * on(cluster_id) group_left () max by (cluster_id) (
+                                    appuio_managed_info{
+                                      vshn_service_level=~"guaranteed_availability|professional",
+                                      cilium_addons=~".*tetragon.*"
+                                    }
+                                  )
+                                  , "instance", "", "node"
+                                )
                               )
                           )
                       )[59m:1m]


### PR DESCRIPTION
This speeds up the query significantly and also guards against broken node labels on clusters that don't matter.




## Checklist

- [x] PR contains a single logical change (to build a better changelog).
- [x] Categorize the PR by setting a good title and adding one of the labels:
      `bug`, `enhancement`, `documentation`, `change`, `breaking`, `dependency`
      as they show up in the changelog.

<!--
Thank you for your pull request. Please provide a description above and
review the checklist.

Contributors guide: ./CONTRIBUTING.md

Remove items that do not apply. For completed items, change [ ] to [x].
These things are not required to open a PR and can be done afterwards,
while the PR is open.
-->
